### PR TITLE
Some minor fixes

### DIFF
--- a/json.c
+++ b/json.c
@@ -120,7 +120,7 @@ static char *character_escape[] = {
 /* define all states and actions that will be taken on each transition.
  *
  * states are defined first because of the fact they are use as index in the
- * transitions table. they usually contains either a number or a prefix _ 
+ * transitions table. they usually contains either a number or a prefix _
  * for simple state like string, object, value ...
  *
  * actions are defined starting from 0x80. state error is defined as 0xff


### PR DESCRIPTION
The two first patches fix a non-logical thing : casting an unsigned as a signed to compare it with unsigned.
The third one is more a warning fix : as the 'printer' parameter is unused. Then I chose to reset it.
The last one is to remove an unused trailing white space (you can ignore this one).
