### PR TITLE
Remove redundant check

### DIFF
--- a/jsonlint.c
+++ b/jsonlint.c
@@ -517,8 +517,6 @@ int main(int argc, char **argv)
 			break;
 		}
 	}
-	if (config.max_nesting < 0)
-		config.max_nesting = 0;
 	if (!output)
 		output = "-";
 	if (optind >= argc)


### PR DESCRIPTION
`max_nesting` is a `uint32_t`, so the given test can never succeed.
