### PR TITLE
Fix memory reallocation bug

### DIFF
--- a/json.c
+++ b/json.c
@@ -979,7 +979,7 @@ static int dom_push(struct json_parser_dom *ctx, void *val)
 	if (ctx->stack_offset == ctx->stack_size) {
 		void *ptr;
 		uint32_t newsize = ctx->stack_size * 2;
-		ptr = memory_realloc(ctx->user_realloc, ctx->stack, newsize);
+		ptr = memory_realloc(ctx->user_realloc, ctx->stack, newsize * sizeof(*(ctx->stack)));
 		if (!ptr)
 			return JSON_ERROR_NO_MEMORY;
 		ctx->stack = ptr;


### PR DESCRIPTION
A bug in memory reallocation caused stack growth past the initial size to result in a heap buffer overflow.
This changes the `memory_realloc` call in `dom_push` to allocate `newsize` _elements_ instead of `newsize` _bytes_.

This appears to fix issue #20.